### PR TITLE
[12. Fix] Move all view state variable to state property

### DIFF
--- a/SpeedcubeTimer.xcodeproj/project.pbxproj
+++ b/SpeedcubeTimer.xcodeproj/project.pbxproj
@@ -323,12 +323,12 @@
 			path = State;
 			sourceTree = "<group>";
 		};
-		E796C00A2822E22A0092EE59 /* VIew */ = {
+		E796C00A2822E22A0092EE59 /* View */ = {
 			isa = PBXGroup;
 			children = (
 				E85499BF27EF65E000FA8FF1 /* SettingsView.swift */,
 			);
-			path = VIew;
+			path = View;
 			sourceTree = "<group>";
 		};
 		E796C00B2822E2300092EE59 /* State */ = {
@@ -354,7 +354,7 @@
 			isa = PBXGroup;
 			children = (
 				E796C00B2822E2300092EE59 /* State */,
-				E796C00A2822E22A0092EE59 /* VIew */,
+				E796C00A2822E22A0092EE59 /* View */,
 			);
 			path = Settings;
 			sourceTree = "<group>";

--- a/SpeedcubeTimer.xcodeproj/project.pbxproj
+++ b/SpeedcubeTimer.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		E763E09528327E6D0051DE7E /* ResultsViewStateReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E763E09428327E6D0051DE7E /* ResultsViewStateReducer.swift */; };
 		E763E09728327E7A0051DE7E /* ResultsViewStateAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E763E09628327E7A0051DE7E /* ResultsViewStateAction.swift */; };
 		E796C00F2822E3440092EE59 /* SettingsViewStateAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E796C00E2822E3440092EE59 /* SettingsViewStateAction.swift */; };
+		E799AB7828C9FBEB00E8F18E /* TimeInterval+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79D878327F2FCC900C39780 /* TimeInterval+Additions.swift */; };
 		E79D878427F2FCC900C39780 /* TimeInterval+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79D878327F2FCC900C39780 /* TimeInterval+Additions.swift */; };
 		E79D878627F3AAC600C39780 /* ResultDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79D878527F3AAC600C39780 /* ResultDetailView.swift */; };
 		E79F0A1428C226F30041EF2C /* SettingsViewStateReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79F0A1328C226F30041EF2C /* SettingsViewStateReducerTests.swift */; };
@@ -671,6 +672,7 @@
 				E73D687128B0489100B41034 /* TimerViewState.swift in Sources */,
 				E73D687D28B223CF00B41034 /* ResultsViewStateReducerTests.swift in Sources */,
 				E73D687B28B04A5000B41034 /* String+Additions.swift in Sources */,
+				E799AB7828C9FBEB00E8F18E /* TimeInterval+Additions.swift in Sources */,
 				E73D687728B048AA00B41034 /* ResultsViewStateReducer.swift in Sources */,
 				E73A67E428BC136B0013B2AC /* MainViewStateReducerTests.swift in Sources */,
 				E73A67E228BC130F0013B2AC /* MainViewStateReducer.swift in Sources */,

--- a/SpeedcubeTimer/Application/Screens/Main/State/MainViewState.swift
+++ b/SpeedcubeTimer/Application/Screens/Main/State/MainViewState.swift
@@ -10,11 +10,13 @@ import Foundation
 struct MainViewState: Equatable {
     let isPresentingOverlay: Bool
     let overlayText: String
+    let tabSelection: Int
 }
 
 extension MainViewState {
     init() {
         isPresentingOverlay = false
         overlayText = .empty
+        tabSelection = 1
     }
 }

--- a/SpeedcubeTimer/Application/Screens/Main/State/MainViewStateAction.swift
+++ b/SpeedcubeTimer/Application/Screens/Main/State/MainViewStateAction.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum MainViewStateAction: Action {
+    case selectionChanged(_ selection: Int)
     case showOverlay(text: String)
     case hideOverlay
 }

--- a/SpeedcubeTimer/Application/Screens/Main/State/MainViewStateReducer.swift
+++ b/SpeedcubeTimer/Application/Screens/Main/State/MainViewStateReducer.swift
@@ -10,17 +10,21 @@ import Foundation
 extension MainViewState {
     static let reducer: Reducer<Self> = { state, action in
         
-        if let action = action as? MainViewStateAction {
-            switch action {
-            case .showOverlay(let text):
-                return MainViewState(isPresentingOverlay: true,
-                                     overlayText: text)
-            case .hideOverlay:
-                return MainViewState(isPresentingOverlay: false,
-                                     overlayText: .empty)
-            }
+        switch action {
+        case MainViewStateAction.selectionChanged(let selection):
+            return MainViewState(isPresentingOverlay: state.isPresentingOverlay,
+                                 overlayText: state.overlayText,
+                                 tabSelection: selection)
+        case MainViewStateAction.showOverlay(let text):
+            return MainViewState(isPresentingOverlay: true,
+                                 overlayText: text,
+                                 tabSelection: state.tabSelection)
+        case MainViewStateAction.hideOverlay:
+            return MainViewState(isPresentingOverlay: false,
+                                 overlayText: .empty,
+                                 tabSelection: state.tabSelection)
+        default:
+            return state
         }
-        
-        return state
     }
 }

--- a/SpeedcubeTimer/Application/Screens/Main/View/MainView.swift
+++ b/SpeedcubeTimer/Application/Screens/Main/View/MainView.swift
@@ -9,13 +9,13 @@ import SwiftUI
 
 struct MainView: View {
     @EnvironmentObject var store: Store<AppState>
-    @State private var selection: Int = 1
     
     var state: MainViewState { store.state.screenState(for: .main) ?? .init() }
     
     var body: some View {
         ZStack {
-            TabView(selection: $selection) {
+            TabView(selection: Binding(get: { state.tabSelection },
+                                       set: { store.dispatch(MainViewStateAction.selectionChanged($0)) })) {
                 ResultsListView()
                     .tabItem {
                         Label("Results", systemImage: "list.number")

--- a/SpeedcubeTimer/Application/Screens/ResultsList/State/ResultsViewStateReducer.swift
+++ b/SpeedcubeTimer/Application/Screens/ResultsList/State/ResultsViewStateReducer.swift
@@ -12,10 +12,8 @@ extension ResultsViewState {
         
         if let action = action as? AppStateAction {
             switch action {
-            case .newSessionSet(let newSession):
+            case .newSessionsSet(let newSession, _):
                 return ResultsViewState(currentSession: newSession)
-            default:
-                break
             }
         }
         

--- a/SpeedcubeTimer/Application/Screens/Settings/State/SettingsViewState.swift
+++ b/SpeedcubeTimer/Application/Screens/Settings/State/SettingsViewState.swift
@@ -15,9 +15,9 @@ struct SettingsViewState: Equatable {
     static let availableCubes: [Cube] = Cube.allCases
     static let availableSessionNums: [Int] = Array(1...10)
     
-    func identifierForSession(with cube: Cube, and index: Int) -> String? {
+    func identifierForSession(with index: Int) -> String? {
         allSessions
-            .filter { $0.cube == cube && $0.index == index }
+            .filter { $0.cube == currentSession.cube && $0.index == index }
             .first?
             .name
     }

--- a/SpeedcubeTimer/Application/Screens/Settings/State/SettingsViewState.swift
+++ b/SpeedcubeTimer/Application/Screens/Settings/State/SettingsViewState.swift
@@ -9,6 +9,8 @@ import Foundation
 
 struct SettingsViewState: Equatable {
     let allSessions: [CubingSession]
+    let currentSession: CubingSession
+    let isPreinspectionOn: Bool
     
     static let availableCubes: [Cube] = Cube.allCases
     static let availableSessionNums: [Int] = Array(1...10)
@@ -23,7 +25,16 @@ struct SettingsViewState: Equatable {
 
 extension SettingsViewState {
     init() {
-        allSessions = [.init()]
+        let session = CubingSession()
+        allSessions = [session]
+        currentSession = session
+        isPreinspectionOn = false
+    }
+    
+    init(allSessions: [CubingSession]) {
+        self.allSessions = allSessions
+        self.currentSession = allSessions.first ?? .init()
+        self.isPreinspectionOn = false
     }
 }
 

--- a/SpeedcubeTimer/Application/Screens/Settings/State/SettingsViewStateReducer.swift
+++ b/SpeedcubeTimer/Application/Screens/Settings/State/SettingsViewStateReducer.swift
@@ -10,15 +10,17 @@ import Foundation
 extension SettingsViewState {
     static let reducer: Reducer<Self> = { state, action in
         
-        if let action = action as? AppStateAction {
-            switch action {
-            case .newAllSessionsSet(let allSessions):
-                return SettingsViewState(allSessions: allSessions)
-            default:
-                break
-            }
+        switch action {
+        case AppStateAction.newSessionsSet(let newCurrent, let newAllSessions):
+            return SettingsViewState(allSessions: newAllSessions,
+                                     currentSession: newCurrent,
+                                     isPreinspectionOn: state.isPreinspectionOn)
+        case SettingsViewStateAction.isPreinspectionOnChanged(let isPreinspectionOn):
+            return SettingsViewState(allSessions: state.allSessions,
+                                     currentSession: state.currentSession,
+                                     isPreinspectionOn: isPreinspectionOn)
+        default:
+            return state
         }
-        
-        return state
     }
 }

--- a/SpeedcubeTimer/Application/Screens/Settings/View/SettingsView.swift
+++ b/SpeedcubeTimer/Application/Screens/Settings/View/SettingsView.swift
@@ -12,59 +12,40 @@ struct SettingsView: View {
     
     private var state: SettingsViewState { store.state.screenState(for: .settings) ?? .init() }
     
-    @State private var currentCube: Cube = .three
-    @State private var currentSession: Int = 1
-    @State private var sessionName: String = .empty
-    @State private var isPreinspectionOn: Bool = false
-    
     var body: some View {
         NavigationView {
             Form {
                 Section(header: Text("Current session")) {
-                    Picker("Cube", selection: $currentCube) {
+                    Picker("Cube", selection: Binding(get: { state.currentSession.cube },
+                                                      set: { store.dispatch(SettingsViewStateAction.cubeChanged($0)) })) {
                         ForEach(SettingsViewState.availableCubes, id: \.self) { option in
                             Text(option.name)
                         }
                     }
                     
-                    Picker("Session", selection: $currentSession) {
+                    Picker("Session", selection: Binding(get: { state.currentSession.index },
+                                                         set: { store.dispatch(SettingsViewStateAction.sessionIndexChanged($0)) })) {
                         ForEach(SettingsViewState.availableSessionNums, id: \.self) { option in
-                            Text("\(option) \(state.identifierForSession(with: currentCube, and: option)?.wrappedInParentheses(true) ?? .empty)")
+                            Text("\(option) \(state.identifierForSession(with: state.currentSession.cube, and: option)?.wrappedInParentheses(true) ?? .empty)")
                         }
                     }
                     
-                    TextField("Session identifier", text: $sessionName, onCommit: {
-                        store.dispatch(SettingsViewStateAction.currentSessionNameChanged(sessionName))
-                    })
+                    TextField("Session identifier", text: Binding(get: { state.currentSession.name ?? .empty },
+                                                                  set: { store.dispatch(SettingsViewStateAction.currentSessionNameChanged($0)) }))
                 }
                 
                 Section(header: Text("General")) {
-                    Toggle("Preinspection", isOn: $isPreinspectionOn)
+                    Toggle("Preinspection", isOn: Binding(get: { state.isPreinspectionOn },
+                                                          set: { store.dispatch(SettingsViewStateAction.isPreinspectionOnChanged($0)) }))
                 }
             }
             .navigationTitle("Settings")
-            .onAppear {
-                sessionName = state.identifierForSession(with: currentCube, and: currentSession) ?? .empty
-            }
-            .onChange(of: currentCube) {
-                store.dispatch(SettingsViewStateAction.cubeChanged($0))
-            }
-            .onChange(of: currentSession) {
-                store.dispatch(SettingsViewStateAction.sessionIndexChanged($0))
-            }
-            .onChange(of: isPreinspectionOn) {
-                store.dispatch(SettingsViewStateAction.isPreinspectionOnChanged($0))
-            }
         }
     }
 }
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsView()
-            .environmentObject(Store(initial: AppState(), reducer: AppState.reducer))
-            .preferredColorScheme(.dark)
-        
         SettingsView()
             .environmentObject(
                 Store(initial:

--- a/SpeedcubeTimer/Application/Screens/Settings/View/SettingsView.swift
+++ b/SpeedcubeTimer/Application/Screens/Settings/View/SettingsView.swift
@@ -26,7 +26,7 @@ struct SettingsView: View {
                     Picker("Session", selection: Binding(get: { state.currentSession.index },
                                                          set: { store.dispatch(SettingsViewStateAction.sessionIndexChanged($0)) })) {
                         ForEach(SettingsViewState.availableSessionNums, id: \.self) { option in
-                            Text("\(option) \(state.identifierForSession(with: state.currentSession.cube, and: option)?.wrappedInParentheses(true) ?? .empty)")
+                            Text("\(option) \(state.identifierForSession(with: option)?.wrappedInParentheses(true) ?? .empty)")
                         }
                     }
                     

--- a/SpeedcubeTimer/Application/Screens/Timer/State/TimerViewState.swift
+++ b/SpeedcubeTimer/Application/Screens/Timer/State/TimerViewState.swift
@@ -14,6 +14,14 @@ struct TimerViewState: Equatable {
     let cube: Cube
     let scramble: String
     let isPreinspectionOn: Bool
+    
+    var formattedTime: String {
+        if cubingState == .preinspectionOngoing || cubingState == .preinspectionReady {
+            return time.asTextOnlyFractionalPart
+        } else {
+            return time.asTextWithTwoDecimal
+        }
+    }
 }
 
 extension TimerViewState {

--- a/SpeedcubeTimer/Application/Screens/Timer/State/TimerViewStateReducer.swift
+++ b/SpeedcubeTimer/Application/Screens/Timer/State/TimerViewStateReducer.swift
@@ -12,14 +12,12 @@ extension TimerViewState {
         
         if let action = action as? AppStateAction {
             switch action {
-            case .newSessionSet(let newSession):
+            case .newSessionsSet(let newSession, _):
                 return TimerViewState(cubingState: state.cubingState,
                                       time: state.time,
                                       cube: newSession.cube,
                                       scramble: ScrambleProvider.newScramble(for: newSession.cube),
                                       isPreinspectionOn: state.isPreinspectionOn)
-            default:
-                break
             }
         }
         

--- a/SpeedcubeTimer/Application/Screens/Timer/View/TimerView.swift
+++ b/SpeedcubeTimer/Application/Screens/Timer/View/TimerView.swift
@@ -18,14 +18,6 @@ struct TimerView: View {
     
     var state: TimerViewState { store.state.screenState(for: .timer) ?? .init() }
     
-    var timeString: String {
-        if state.cubingState == .preinspectionOngoing || state.cubingState == .preinspectionReady {
-            return state.time.asTextOnlyFractionalPart
-        } else {
-            return state.time.asTextWithTwoDecimal
-        }
-    }
-    
     @State private var timer: Timer?
     
     var body: some View {
@@ -45,7 +37,7 @@ struct TimerView: View {
                             .padding(.horizontal, 15)
                     )
                 
-                Text(timeString)
+                Text(state.formattedTime)
                     .foregroundColor(state.cubingState.timerTextColor)
                     .font(.system(size: 70))
                     .multilineTextAlignment(.center)

--- a/SpeedcubeTimer/Application/State/AppStateAction.swift
+++ b/SpeedcubeTimer/Application/State/AppStateAction.swift
@@ -10,6 +10,5 @@ import Foundation
 // MARK: - Action
 
 enum AppStateAction: Action {
-    case newAllSessionsSet(_ sessions: [CubingSession])
-    case newSessionSet(_ session: CubingSession)
+    case newSessionsSet(current: CubingSession, allSessions: [CubingSession])
 }

--- a/SpeedcubeTimer/Application/State/AppStateReducer.swift
+++ b/SpeedcubeTimer/Application/State/AppStateReducer.swift
@@ -15,99 +15,85 @@ extension AppState {
         var newAllSessions = state.allSessions
         var newActions = [action]
         
-        if let action = action as? SettingsViewStateAction {
-            switch action {
-            case .currentSessionNameChanged(let name):
-                newSession = .init(results: newSession.results,
-                                   cube: newSession.cube,
-                                   index: newSession.index,
-                                   name: (name == .empty ? nil : name),
-                                   id: newSession.id)
-                newAllSessions.removeAll { $0.id == newSession.id }
-                newAllSessions.append(newSession)
-                newActions = [
-                    AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
-                ]
-            case .cubeChanged(let newCube):
-                let tmpNewSession = state.session(for: newCube, and: state.currentSession.index)
-                let tmpAllSessions: [CubingSession] = {
-                    if !state.allSessions.contains(tmpNewSession) {
-                        return state.allSessions + [tmpNewSession]
-                    } else {
-                        return state.allSessions
-                    }
-                }()
-                newSession = tmpNewSession
-                newAllSessions = tmpAllSessions
-                newActions = [
-                    AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
-                ]
-            case .sessionIndexChanged(let newIndex):
-                let tmpNewSession = state.session(for: state.currentSession.cube, and: newIndex)
-                let tmpAllSessions: [CubingSession] = {
-                    if !state.allSessions.contains(tmpNewSession) {
-                        return state.allSessions + [tmpNewSession]
-                    } else {
-                        return state.allSessions
-                    }
-                }()
-                newSession = tmpNewSession
-                newAllSessions = tmpAllSessions
-                newActions = [
-                    AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
-                ]
-            default:
-                break
-            }
-        }
-        
-        if let action = action as? TimerViewStateAction {
-            switch action {
-            case .saveResult(let newResult):
-                let oldSession = state.currentSession
-                var newResults = oldSession.results
-                newResults.insert(newResult, at: 0)
-                newSession = .init(results: newResults,
-                                   cube: oldSession.cube,
-                                   index: oldSession.index,
-                                   name: oldSession.name,
-                                   id: oldSession.id)
-                
-                newAllSessions.removeAll { $0.id == oldSession.id }
-                newAllSessions.append(newSession)
-                newActions = [
-                    AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
-                ]
-                if newSession.bestResult != oldSession.bestResult {
-                    newActions.append(MainViewStateAction.showOverlay(text: "🤩 new best single 🥳"))
-                } else if newSession.bestAvgOf(5, mode: .avgOf) != oldSession.bestAvgOf(5, mode: .avgOf) {
-                    newActions.append(MainViewStateAction.showOverlay(text: "🤯 new best avg5 😱"))
-                } else if newSession.bestAvgOf(12, mode: .avgOf) != oldSession.bestAvgOf(12, mode: .avgOf) {
-                    newActions.append(MainViewStateAction.showOverlay(text: "🎉 new best avg12 🎉"))
+        switch action {
+        case SettingsViewStateAction.currentSessionNameChanged(let name):
+            newSession = .init(results: newSession.results,
+                               cube: newSession.cube,
+                               index: newSession.index,
+                               name: (name == .empty ? nil : name),
+                               id: newSession.id)
+            newAllSessions.removeAll { $0.id == newSession.id }
+            newAllSessions.append(newSession)
+            newActions = [
+                AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
+            ]
+        case SettingsViewStateAction.cubeChanged(let newCube):
+            let tmpNewSession = state.session(for: newCube, and: state.currentSession.index)
+            let tmpAllSessions: [CubingSession] = {
+                if !state.allSessions.contains(tmpNewSession) {
+                    return state.allSessions + [tmpNewSession]
+                } else {
+                    return state.allSessions
                 }
-            default:
-                break
+            }()
+            newSession = tmpNewSession
+            newAllSessions = tmpAllSessions
+            newActions = [
+                AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
+            ]
+        case SettingsViewStateAction.sessionIndexChanged(let newIndex):
+            let tmpNewSession = state.session(for: state.currentSession.cube, and: newIndex)
+            let tmpAllSessions: [CubingSession] = {
+                if !state.allSessions.contains(tmpNewSession) {
+                    return state.allSessions + [tmpNewSession]
+                } else {
+                    return state.allSessions
+                }
+            }()
+            newSession = tmpNewSession
+            newAllSessions = tmpAllSessions
+            newActions = [
+                AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
+            ]
+        case TimerViewStateAction.saveResult(let newResult):
+            let oldSession = state.currentSession
+            var newResults = oldSession.results
+            newResults.insert(newResult, at: 0)
+            newSession = .init(results: newResults,
+                               cube: oldSession.cube,
+                               index: oldSession.index,
+                               name: oldSession.name,
+                               id: oldSession.id)
+            
+            newAllSessions.removeAll { $0.id == oldSession.id }
+            newAllSessions.append(newSession)
+            newActions = [
+                AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
+            ]
+            if newSession.bestResult != oldSession.bestResult {
+                newActions.append(MainViewStateAction.showOverlay(text: "🤩 new best single 🥳"))
+            } else if newSession.bestAvgOf(5, mode: .avgOf) != oldSession.bestAvgOf(5, mode: .avgOf) {
+                newActions.append(MainViewStateAction.showOverlay(text: "🤯 new best avg5 😱"))
+            } else if newSession.bestAvgOf(12, mode: .avgOf) != oldSession.bestAvgOf(12, mode: .avgOf) {
+                newActions.append(MainViewStateAction.showOverlay(text: "🎉 new best avg12 🎉"))
             }
-        }
-        
-        if let action = action as? ResultsViewStateAction {
-            switch action {
-            case .removeResultsAt(let offsets):
-                let oldSession = state.currentSession
-                var newResults = oldSession.results
-                newResults.remove(atOffsets: offsets)
-                newSession = .init(results: newResults,
-                                   cube: oldSession.cube,
-                                   index: oldSession.index,
-                                   name: oldSession.name,
-                                   id: oldSession.id)
-                
-                newAllSessions.removeAll { $0.id == oldSession.id }
-                newAllSessions.append(newSession)
-                newActions = [
-                    AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
-                ]
-            }
+        case ResultsViewStateAction.removeResultsAt(let offsets):
+            let oldSession = state.currentSession
+            var newResults = oldSession.results
+            newResults.remove(atOffsets: offsets)
+            newSession = .init(results: newResults,
+                               cube: oldSession.cube,
+                               index: oldSession.index,
+                               name: oldSession.name,
+                               id: oldSession.id)
+            
+            newAllSessions.removeAll { $0.id == oldSession.id }
+            newAllSessions.append(newSession)
+            newActions = [
+                AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
+            ]
+        default:
+            break
         }
         
         let newScreens = state.screens.map { (screenState: AppScreenState) -> AppScreenState in

--- a/SpeedcubeTimer/Application/State/AppStateReducer.swift
+++ b/SpeedcubeTimer/Application/State/AppStateReducer.swift
@@ -26,8 +26,7 @@ extension AppState {
                 newAllSessions.removeAll { $0.id == newSession.id }
                 newAllSessions.append(newSession)
                 newActions = [
-                    AppStateAction.newSessionSet(newSession),
-                    AppStateAction.newAllSessionsSet(newAllSessions)
+                    AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
                 ]
             case .cubeChanged(let newCube):
                 let tmpNewSession = state.session(for: newCube, and: state.currentSession.index)
@@ -40,7 +39,9 @@ extension AppState {
                 }()
                 newSession = tmpNewSession
                 newAllSessions = tmpAllSessions
-                newActions = [AppStateAction.newSessionSet(newSession)]
+                newActions = [
+                    AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
+                ]
             case .sessionIndexChanged(let newIndex):
                 let tmpNewSession = state.session(for: state.currentSession.cube, and: newIndex)
                 let tmpAllSessions: [CubingSession] = {
@@ -52,7 +53,9 @@ extension AppState {
                 }()
                 newSession = tmpNewSession
                 newAllSessions = tmpAllSessions
-                newActions = [AppStateAction.newSessionSet(newSession)]
+                newActions = [
+                    AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
+                ]
             default:
                 break
             }
@@ -72,7 +75,9 @@ extension AppState {
                 
                 newAllSessions.removeAll { $0.id == oldSession.id }
                 newAllSessions.append(newSession)
-                newActions = [AppStateAction.newSessionSet(newSession)]
+                newActions = [
+                    AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
+                ]
                 if newSession.bestResult != oldSession.bestResult {
                     newActions.append(MainViewStateAction.showOverlay(text: "🤩 new best single 🥳"))
                 } else if newSession.bestAvgOf(5, mode: .avgOf) != oldSession.bestAvgOf(5, mode: .avgOf) {
@@ -99,7 +104,9 @@ extension AppState {
                 
                 newAllSessions.removeAll { $0.id == oldSession.id }
                 newAllSessions.append(newSession)
-                newActions = [AppStateAction.newSessionSet(newSession)]
+                newActions = [
+                    AppStateAction.newSessionsSet(current: newSession, allSessions: newAllSessions)
+                ]
             }
         }
         

--- a/SpeedcubeTimerTests/StateTests/MainViewStateReducerTests.swift
+++ b/SpeedcubeTimerTests/StateTests/MainViewStateReducerTests.swift
@@ -48,7 +48,7 @@ class MainViewStateReducerTests: XCTestCase {
 }
 
 private enum Configuration {
-    static let mainStateDefault: MainViewState = .init(isPresentingOverlay: false, overlayText: .empty)
-    static let mainStatePresentingOverlay: MainViewState = .init(isPresentingOverlay: true, overlayText: .empty)
+    static let mainStateDefault: MainViewState = .init(isPresentingOverlay: false, overlayText: .empty, tabSelection: 1)
+    static let mainStatePresentingOverlay: MainViewState = .init(isPresentingOverlay: true, overlayText: .empty, tabSelection: 1)
     static let overlayText: String = "Great"
 }

--- a/SpeedcubeTimerTests/StateTests/ResultsViewStateReducerTests.swift
+++ b/SpeedcubeTimerTests/StateTests/ResultsViewStateReducerTests.swift
@@ -26,7 +26,7 @@ class ResultsViewStateReducerTests: XCTestCase {
         
         // Reduce
         
-        let reduced = ResultsViewState.reducer(resultsViewStateBefore, AppStateAction.newSessionSet(session2))
+        let reduced = ResultsViewState.reducer(resultsViewStateBefore, AppStateAction.newSessionsSet(current: session2, allSessions: [session2]))
         
         // Test
         

--- a/SpeedcubeTimerTests/StateTests/SettingsViewStateReducerTests.swift
+++ b/SpeedcubeTimerTests/StateTests/SettingsViewStateReducerTests.swift
@@ -20,7 +20,7 @@ final class SettingsViewStateReducerTests: XCTestCase {
         
         // Reduce
         
-        let reduced = SettingsViewState.reducer(beforeState, AppStateAction.newAllSessionsSet(Configuration.sampleSessions2))
+        let reduced = SettingsViewState.reducer(beforeState, AppStateAction.newSessionsSet(current: afterSessions.first!, allSessions: afterSessions))
         
         // Test
         

--- a/SpeedcubeTimerTests/StateTests/TimerViewStateReducerTests.swift
+++ b/SpeedcubeTimerTests/StateTests/TimerViewStateReducerTests.swift
@@ -26,7 +26,7 @@ class TimerViewStateReducerTests: XCTestCase {
         
         // Reduce
         
-        let reduced = TimerViewState.reducer(timerViewStateBefore, AppStateAction.newSessionSet(session2))
+        let reduced = TimerViewState.reducer(timerViewStateBefore, AppStateAction.newSessionsSet(current: session2, allSessions: [session2]))
         
         // Test
         


### PR DESCRIPTION
Moved all state variables to state properties, excluding timer property from timer view - it requires some new component to get it working like that - maybe using TCA would solve it.
Tests updated to not fail but not updated for all new actions since work with TCA might change how tests are executed.